### PR TITLE
Fix melon default image

### DIFF
--- a/src/Resources/AlbumNullResource.php
+++ b/src/Resources/AlbumNullResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Cable8mm\WaterMelon\Resources;
+
+class AlbumResource extends Resource
+{
+    public function toArray()
+    {
+        return [
+            'melon_albumid' => $this->melon['ALBUMINFO']['ALBUMID'],
+            'title' => $this->melon['ALBUMINFO']['ALBUMNAME'],
+            'album_cover_path' => self::emptyToNull($this->melon['ALBUMINFO']['ALBUMIMG']),
+            'released_at' => $this->melon['ALBUMINFO']['ISSUEDATE'],
+        ];
+    }
+}

--- a/src/Resources/ArtistNullResource.php
+++ b/src/Resources/ArtistNullResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Cable8mm\WaterMelon\Resources;
+
+class ArtistNullResource extends Resource
+{
+    public function toArray()
+    {
+        // TODO : birth, sns, activity_regiment, activity_type, agency, genre
+        return [
+            'melon_artistid' => $this->melon['ARTISTID'],
+            'name' => $this->melon['ARTISTNAME'],
+            'featured_image_path' => self::emptyToNull($this->melon['ARTISTIMGLARGE']),
+            'profile_image_path' => self::emptyToNull($this->melon['POSTIMG']),
+            'birth' => null,
+            'sns' => null,
+            'debut' => $this->melon['ARTISTNOTEINFO']['ISSUEDATE'] ?? null,
+            'activity_regiment' => null,
+            'activity_type' => null,
+            'agency' => null,
+            'genre' => null,
+        ];
+    }
+}

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -51,4 +51,14 @@ abstract class Resource implements ArrayAccess
     {
         return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
+
+    /**
+     * Melon default image path to null
+     *
+     * @example https://cdnimg.melon.co.kr/resource/mobile40/cds/common/image/sns_post_default_500.jpg
+     */
+    public static function emptyToNull(string|null $path): string|null
+    {
+        return  empty($path) || preg_match('/_default_[^\/]+\.jpg/', $path) ? null : $path;
+    }
 }

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -59,6 +59,6 @@ abstract class Resource implements ArrayAccess
      */
     public static function emptyToNull(string|null $path): string|null
     {
-        return  empty($path) || preg_match('/_default_[^\/]+\.jpg/', $path) ? null : $path;
+        return empty($path) || preg_match('/_default_[^\/]+\.jpg/', $path) ? null : $path;
     }
 }

--- a/src/Resources/SongNullResource.php
+++ b/src/Resources/SongNullResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Cable8mm\WaterMelon\Resources;
+
+class SongResource extends Resource
+{
+    public function toArray()
+    {
+        return [
+            'album_id' => $this->melon['SONGINFO']['ALBUMID'],
+            'melon_songid' => $this->melon['SONGINFO']['SONGID'],
+            'title' => $this->melon['SONGINFO']['SONGNAME'],
+            'artwork_image_path' => self::emptyToNull($this->melon['SONGINFO']['ALBUMIMG']),
+        ];
+    }
+}

--- a/tests/ArtistNullResourceTest.php
+++ b/tests/ArtistNullResourceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Cable8mm\WaterMelon\Tests;
+
+use Cable8mm\WaterMelon\MelonArtist;
+use Cable8mm\WaterMelon\Resources\ArtistNullResource;
+use PHPUnit\Framework\TestCase;
+
+final class ArtistNullResourceTest extends TestCase
+{
+    public function test_havnt_image_artist_resource()
+    {
+        $melonArtist = MelonArtist::make(3102913);   // HEYA
+
+        $artistResource = ArtistNullResource::make($melonArtist);
+
+        $this->assertNull($artistResource->featured_image_path);
+        $this->assertNull($artistResource->profile_image_path);
+    }
+
+    public function test_has_image_artist_resource()
+    {
+        $melonArtist = MelonArtist::make(3055146);   // IVE
+
+        $artistResource = ArtistNullResource::make($melonArtist);
+
+        $this->assertEquals('https://cdnimg.melon.co.kr/cm2/artistcrop/images/030/55/146/3055146_20230410142647_org.jpg?0453ee96ef852e4d5ce0e98daacc4d6a/melon/resize/1000/optimize/90', $artistResource->featured_image_path);
+    }
+}


### PR DESCRIPTION
Added a resource that returns null if the image in Melon's response is the default image created by Melon.